### PR TITLE
I've updated the initial UI query to use the first loaded table name …

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { initializeDatabase } from './db.js';
+import { initializeDatabase, generateTableNameFromUrl } from './db.js';
 import { executeQuery } from './query.js';
 import { fileSources } from './csvSources.js'; // Import the updated sources
 
@@ -16,6 +16,22 @@ initializeDatabase(fileSources) // Use the updated fileSources
     .then(() => {
         // Database is initialized (or attempted to initialize with data from URLs), and db instance in db.js is set.
         // executeQuery (imported from query.js) will use that db instance.
+        try {
+            if (fileSources && fileSources.length > 0) {
+                const firstFileSource = fileSources[0];
+                if (firstFileSource && firstFileSource.url) {
+                    let firstTableName = generateTableNameFromUrl(firstFileSource.url);
+                    console.log(`First table name determined: ${firstTableName}`);
+
+                    const sqlInput = document.getElementById('sql-input');
+                    if (firstTableName && sqlInput) {
+                        sqlInput.value = `SELECT * FROM ${firstTableName} LIMIT 5;`;
+                    }
+                }
+            }
+        } catch (error) {
+            console.error(`Could not dynamically set initial query: ${error.message}`);
+        }
         console.log("Database initialized. Executing initial query...");
         executeQuery(); // Execute initial query to display data
     })


### PR DESCRIPTION
…dynamically.

Previously, the initial SQL query in the UI was hardcoded. This change modifies `js/main.js` so that I can:
- Determine the name of the first table loaded based on `fileSources`.
- Use this dynamic table name to construct the initial `SELECT` query.
- Update the `sql-input` textarea with this new query before it's executed on page load.
- This includes error handling in case the first table name cannot be determined, falling back to the default query.