### PR TITLE
Fix: Update CSS for scrolling behavior

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,6 +21,8 @@ h1, h2 {
     border: 1px solid #b3d9ff;
     border-radius: 5px;
     background-color: #e6f7ff;
+    max-height: 50vh;
+    overflow-y: auto;
 }
 #results {
     margin-top: 20px;
@@ -28,7 +30,6 @@ h1, h2 {
     padding: 15px;
     border-radius: 5px;
     border: 1px solid #cce5ff;
-    max-height: 400px;
     overflow-y: auto;
 }
 #results table { /* Keep table styles in case you want to switch back or for debugging */


### PR DESCRIPTION
This commit updates the CSS for `index.html` to modify the scrolling behavior of the "message printer" and "output" divs.

- The "message printer" div (`#status`) now has a `max-height` of `50vh` and `overflow-y: auto;` to enable vertical scrolling within that height limit.
- The "output" div (`#results`) no longer has a `max-height` constraint and `overflow-y: auto;` is ensured to allow vertical scrolling as content grows.