### PR TITLE
Refactor: Remove unused column exclusion feature from parsers

### DIFF
--- a/js/csvParser.js
+++ b/js/csvParser.js
@@ -3,14 +3,13 @@ import { _parseDelimitedText } from './delimitedTextParser.js';
 /**
  * Parses CSV text into headers and data rows.
  * @param {string} csvText - The raw CSV string.
- * @param {string[]} [excludedColumns] - Optional. An array of column names to exclude.
  * @returns {{headers: string[], dataRows: string[][]}} An object containing headers and dataRows (as an array of arrays of strings).
  */
-function parseCSV(csvText, excludedColumns) {
+function parseCSV(csvText) {
     // Ensure csvText is a string before passing it to _parseDelimitedText
     // If csvText is null or undefined, treat as empty string.
     const textToParse = typeof csvText === 'string' ? csvText : '';
-    return _parseDelimitedText(textToParse, ',', excludedColumns);
+    return _parseDelimitedText(textToParse, ',');
 }
 
 export { parseCSV };

--- a/js/tsvParser.js
+++ b/js/tsvParser.js
@@ -3,13 +3,12 @@ import { _parseDelimitedText } from './delimitedTextParser.js';
 /**
  * Parses TSV text into headers and data rows.
  * @param {string} tsvText - The raw TSV string.
- * @param {string[]} [excludedColumns] - Optional. An array of column names to exclude.
  * @returns {{headers: string[], dataRows: string[][]}} An object containing headers and dataRows (as an array of arrays of strings).
  */
-function parseTSV(tsvText, excludedColumns) {
+function parseTSV(tsvText) {
   // Ensure tsvText is a string, default to empty if null/undefined
   const textToParse = typeof tsvText === 'string' ? tsvText : '';
-  return _parseDelimitedText(textToParse, '\t', excludedColumns);
+  return _parseDelimitedText(textToParse, '\t');
 }
 
 export { parseTSV };

--- a/tests/testCsvParser.js
+++ b/tests/testCsvParser.js
@@ -45,12 +45,12 @@ QUnit.test('should handle empty lines in CSV input', function(assert) {
   const correctedExpected = {
     headers: ['header1', 'header2'],
     // For 'h1,h2\n\nval1,val2\n':
-    // First empty line: keptHeaderIndices [0,1] includes 0 -> ['']
+    // First empty line: now becomes ['', '']
     // val1,val2 -> ['val1','val2']
-    // Trailing empty line: keptHeaderIndices [0,1] includes 0 -> ['']
-    dataRows: [[''], ['value1', 'value2'], ['']]
+    // Trailing empty line: now becomes ['', '']
+    dataRows: [['', ''], ['value1', 'value2'], ['', '']]
   };
-  assert.deepEqual(parseCSV(csvText), correctedExpected, 'Handles empty lines by creating a row with an empty string cell');
+  assert.deepEqual(parseCSV(csvText), correctedExpected, 'Handles empty lines by creating a row with an empty string cell for each header');
 });
 
 QUnit.test('should parse CSV with only headers and no data rows', function(assert) {
@@ -73,102 +73,10 @@ QUnit.test('should handle CSV with trailing newline', function(assert) {
     // dataRows maps over ["v1,v2", ""].
     // The last empty string will become ['']
   };
-   // Reverting to original expectation:
-   // Trailing empty line becomes [''] if first column is kept.
+   // Trailing empty line becomes an array of empty strings, one for each header.
   const correctedExpectedTrailing = {
     headers: ['header1', 'header2'],
-    dataRows: [['value1', 'value2'], ['']]
+    dataRows: [['value1', 'value2'], ['', '']]
   };
   assert.deepEqual(parseCSV(csvText), correctedExpectedTrailing, 'Correctly handles CSV with trailing newline');
-});
-
-QUnit.module('parseCSV - Column Exclusion');
-
-QUnit.test('no exclusion - should work as before', function(assert) {
-  const csvText = 'name,age,city\nAlice,30,New York\nBob,25,Chicago';
-  const expected = {
-    headers: ['name', 'age', 'city'],
-    dataRows: [['Alice', '30', 'New York'], ['Bob', '25', 'Chicago']]
-  };
-  assert.deepEqual(parseCSV(csvText), expected, 'No exclusion: Parses all columns');
-});
-
-QUnit.test('exclude a single existing column', function(assert) {
-  const csvText = 'name,age,city\nAlice,30,New York\nBob,25,Chicago';
-  const excludedColumns = ['age'];
-  const expected = {
-    headers: ['name', 'city'],
-    dataRows: [['Alice', 'New York'], ['Bob', 'Chicago']]
-  };
-  assert.deepEqual(parseCSV(csvText, excludedColumns), expected, 'Exclude single column: "age"');
-});
-
-QUnit.test('exclude multiple existing columns', function(assert) {
-  const csvText = 'name,age,city,country\nAlice,30,New York,USA\nBob,25,Chicago,USA';
-  const excludedColumns = ['age', 'country'];
-  const expected = {
-    headers: ['name', 'city'],
-    dataRows: [['Alice', 'New York'], ['Bob', 'Chicago']]
-  };
-  assert.deepEqual(parseCSV(csvText, excludedColumns), expected, 'Exclude multiple columns: "age", "country"');
-});
-
-QUnit.test('exclude a non-existent column', function(assert) {
-  const csvText = 'name,age,city\nAlice,30,New York';
-  const excludedColumns = ['occupation'];
-  const expected = {
-    headers: ['name', 'age', 'city'],
-    dataRows: [['Alice', '30', 'New York']]
-  };
-  assert.deepEqual(parseCSV(csvText, excludedColumns), expected, 'Exclude non-existent column: "occupation"');
-});
-
-QUnit.test('exclude a mix of existing and non-existent columns', function(assert) {
-  const csvText = 'name,age,city\nAlice,30,New York';
-  const excludedColumns = ['age', 'occupation'];
-  const expected = {
-    headers: ['name', 'city'],
-    dataRows: [['Alice', 'New York']]
-  };
-  assert.deepEqual(parseCSV(csvText, excludedColumns), expected, 'Exclude mix: "age" (exists), "occupation" (non-existent)');
-});
-
-QUnit.test('exclude all columns', function(assert) {
-  const csvText = 'name,age,city\nAlice,30,New York\nBob,25,Chicago';
-  const excludedColumns = ['name', 'age', 'city'];
-  const expected = {
-    headers: [],
-    dataRows: [[], []]
-  };
-  assert.deepEqual(parseCSV(csvText, excludedColumns), expected, 'Exclude all columns');
-});
-
-QUnit.test('pass an empty array for excludedColumns', function(assert) {
-  const csvText = 'name,age,city\nAlice,30,New York';
-  const excludedColumns = [];
-  const expected = {
-    headers: ['name', 'age', 'city'],
-    dataRows: [['Alice', '30', 'New York']]
-  };
-  assert.deepEqual(parseCSV(csvText, excludedColumns), expected, 'Exclude with empty array: no columns excluded');
-});
-
-QUnit.test('pass null for excludedColumns', function(assert) {
-  const csvText = 'name,age,city\nAlice,30,New York';
-  const excludedColumns = null;
-  const expected = {
-    headers: ['name', 'age', 'city'],
-    dataRows: [['Alice', '30', 'New York']]
-  };
-  assert.deepEqual(parseCSV(csvText, excludedColumns), expected, 'Exclude with null: no columns excluded');
-});
-
-QUnit.test('pass undefined for excludedColumns (implicitly by not passing)', function(assert) {
-  const csvText = 'name,age,city\nAlice,30,New York';
-  // Call parseCSV without the second argument
-  const expected = {
-    headers: ['name', 'age', 'city'],
-    dataRows: [['Alice', '30', 'New York']]
-  };
-  assert.deepEqual(parseCSV(csvText), expected, 'Exclude with undefined (argument not passed): no columns excluded');
 });

--- a/tests/testTsvParser.js
+++ b/tests/testTsvParser.js
@@ -24,9 +24,9 @@ QUnit.test('should handle empty lines in TSV input', function(assert) {
   const tsvText = 'header1\theader2\n\nvalue1\tvalue2\n';
   const expected = {
     headers: ['header1', 'header2'],
-    dataRows: [[''], ['value1', 'value2'], ['']] // Empty line becomes [''] if first col kept, same for trailing newline
+    dataRows: [['', ''], ['value1', 'value2'], ['', '']] // Empty line becomes an array of empty strings
   };
-  assert.deepEqual(parseTSV(tsvText), expected, 'Handles empty lines by creating rows with empty string cells');
+  assert.deepEqual(parseTSV(tsvText), expected, 'Handles empty lines by creating rows with empty string cells for each header');
 });
 
 QUnit.test('should parse TSV with only headers and no data rows', function(assert) {
@@ -42,7 +42,7 @@ QUnit.test('should handle TSV with trailing newline', function(assert) {
   const tsvText = 'header1\theader2\nvalue1\tvalue2\n';
   const expected = {
     headers: ['header1', 'header2'],
-    dataRows: [['value1', 'value2'], ['']] // Trailing newline results in a row with an empty cell if first col kept
+    dataRows: [['value1', 'value2'], ['', '']] // Trailing newline results in a row of empty strings
   };
   assert.deepEqual(parseTSV(tsvText), expected, 'Correctly handles TSV with trailing newline');
 });
@@ -63,95 +63,4 @@ QUnit.test('should handle input as newline character', function(assert) {
     dataRows: []   // And empty dataRows, as '' input does not imply presence of a data line.
   };
   assert.deepEqual(parseTSV(tsvText), expected, 'Handles input as newline character');
-});
-
-
-QUnit.module('parseTSV - Column Exclusion');
-
-QUnit.test('no exclusion - should parse all columns', function(assert) {
-  const tsvText = 'name\tage\tcity\nAlice\t30\tNew York';
-  const expected = {
-    headers: ['name', 'age', 'city'],
-    dataRows: [['Alice', '30', 'New York']]
-  };
-  assert.deepEqual(parseTSV(tsvText), expected, 'No exclusion: Parses all columns');
-});
-
-QUnit.test('exclude a single existing column', function(assert) {
-  const tsvText = 'name\tage\tcity\nAlice\t30\tNew York\nBob\t25\tChicago';
-  const excludedColumns = ['age'];
-  const expected = {
-    headers: ['name', 'city'],
-    dataRows: [['Alice', 'New York'], ['Bob', 'Chicago']]
-  };
-  assert.deepEqual(parseTSV(tsvText, excludedColumns), expected, 'Exclude single column: "age"');
-});
-
-QUnit.test('exclude multiple existing columns', function(assert) {
-  const tsvText = 'name\tage\tcity\tcountry\nAlice\t30\tNew York\tUSA\nBob\t25\tChicago\tUSA';
-  const excludedColumns = ['age', 'country'];
-  const expected = {
-    headers: ['name', 'city'],
-    dataRows: [['Alice', 'New York'], ['Bob', 'Chicago']]
-  };
-  assert.deepEqual(parseTSV(tsvText, excludedColumns), expected, 'Exclude multiple columns: "age", "country"');
-});
-
-QUnit.test('exclude a non-existent column', function(assert) {
-  const tsvText = 'name\tage\tcity\nAlice\t30\tNew York';
-  const excludedColumns = ['occupation'];
-  const expected = {
-    headers: ['name', 'age', 'city'],
-    dataRows: [['Alice', '30', 'New York']]
-  };
-  assert.deepEqual(parseTSV(tsvText, excludedColumns), expected, 'Exclude non-existent column: "occupation"');
-});
-
-QUnit.test('exclude a mix of existing and non-existent columns', function(assert) {
-  const tsvText = 'name\tage\tcity\nAlice\t30\tNew York';
-  const excludedColumns = ['age', 'occupation'];
-  const expected = {
-    headers: ['name', 'city'],
-    dataRows: [['Alice', 'New York']]
-  };
-  assert.deepEqual(parseTSV(tsvText, excludedColumns), expected, 'Exclude mix: "age" (exists), "occupation" (non-existent)');
-});
-
-QUnit.test('exclude all columns', function(assert) {
-  const tsvText = 'name\tage\tcity\nAlice\t30\tNew York\nBob\t25\tChicago';
-  const excludedColumns = ['name', 'age', 'city'];
-  const expected = {
-    headers: [],
-    dataRows: [[], []]
-  };
-  assert.deepEqual(parseTSV(tsvText, excludedColumns), expected, 'Exclude all columns');
-});
-
-QUnit.test('pass an empty array for excludedColumns', function(assert) {
-  const tsvText = 'name\tage\tcity\nAlice\t30\tNew York';
-  const excludedColumns = [];
-  const expected = {
-    headers: ['name', 'age', 'city'],
-    dataRows: [['Alice', '30', 'New York']]
-  };
-  assert.deepEqual(parseTSV(tsvText, excludedColumns), expected, 'Exclude with empty array: no columns excluded');
-});
-
-QUnit.test('pass null for excludedColumns', function(assert) {
-  const tsvText = 'name\tage\tcity\nAlice\t30\tNew York';
-  const excludedColumns = null;
-  const expected = {
-    headers: ['name', 'age', 'city'],
-    dataRows: [['Alice', '30', 'New York']]
-  };
-  assert.deepEqual(parseTSV(tsvText, excludedColumns), expected, 'Exclude with null: no columns excluded');
-});
-
-QUnit.test('pass undefined for excludedColumns (implicitly by not passing)', function(assert) {
-  const tsvText = 'name\tage\tcity\nAlice\t30\tNew York';
-  const expected = {
-    headers: ['name', 'age', 'city'],
-    dataRows: [['Alice', '30', 'New York']]
-  };
-  assert.deepEqual(parseTSV(tsvText), expected, 'Exclude with undefined (argument not passed): no columns excluded');
 });


### PR DESCRIPTION
This commit removes the `excludedColumns` parameter and associated logic from `_parseDelimitedText`, `parseCSV`, and `parseTSV` functions. This feature was not being used by the `initializeDatabase` function when loading data.

Changes include:
- Removed `excludedColumns` parameter from `_parseDelimitedText` in `js/delimitedTextParser.js` and simplified its internal logic.
- Updated handling of empty data lines in `_parseDelimitedText` to return an array of empty strings corresponding to the header count, ensuring consistent row structure.
- Removed `excludedColumns` parameter from `parseCSV` in `js/csvParser.js` and updated its call to `_parseDelimitedText`.
- Removed `excludedColumns` parameter from `parseTSV` in `js/tsvParser.js` and updated its call to `_parseDelimitedText`.
- Updated unit tests in `tests/testCsvParser.js` and `tests/testTsvParser.js`:
    - Removed test suites specifically covering the `excludedColumns` functionality.
    - Modified tests for empty lines and trailing newlines to align with the updated parsing behavior in `_parseDelimitedText`.

This change simplifies the parsing code by removing dead code paths.