### PR TITLE
Fix: Resolve SQL.js initialization freeze by removing redundant scrip…

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
         Load sql.js from a CDN. This script will automatically fetch 
         the associated sql-wasm.wasm file.
     -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.3/sql-wasm.js"></script>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/tests/test_db_init_node.js
+++ b/tests/test_db_init_node.js
@@ -1,6 +1,7 @@
 // Node.js test script for initializeDatabase in db.js
 
-import { initializeDatabase, generateTableNameFromUrl } from '../js/db.js';
+import { initializeDataSources as initializeDatabase } from '../js/dataOrchestrator.js';
+import { generateTableNameFromUrl } from '../js/database/sqliteService.js';
 import { fileSources } from '../js/csvSources.js'; // Assuming csvSources.js is in js/
 // Attempting direct import of the sql-wasm.js file due to persistent ERR_MODULE_NOT_FOUND with 'sql.js'
 import originalInitSqlJs from 'sql.js/dist/sql-wasm.js';
@@ -48,6 +49,11 @@ const mockUiFunction = (message, isError, isProgress) => {
 // So, global mocks for these are not needed and wouldn't be used by db.js.
 // We rely on those files existing and exporting the functions.
 
+// --- Dummy Progress Callback ---
+const dummyProgressCallback = (update) => {
+    // console.log(`Test Progress: type=${update.type}, msg=${update.message}, table=${update.tableName}`);
+};
+
 // --- Main Test Logic ---
 async function runTest() {
     console.log('Starting Node.js test for initializeDatabase...');
@@ -80,7 +86,8 @@ async function runTest() {
         });
 
         console.log('Initializing database with sources (file paths resolved):', JSON.stringify(localFileSources, null, 2));
-        const db = await initializeDatabase(localFileSources);
+        // Pass the dummyProgressCallback to initializeDatabase (which is initializeDataSources)
+        const db = await initializeDatabase(localFileSources, dummyProgressCallback);
 
         if (!db) {
             throw new Error('Database initialization returned undefined or null.');


### PR DESCRIPTION
…t tag

The application was freezing with the status 'Initializing SQL.js...' because of a conflict in how SQL.js was being loaded and initialized.

`index.html` included a direct script tag:
`<script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.3/sql-wasm.js"></script>`

This conflicted with the initialization performed in `js/database/sqliteService.js`, which uses `initSqlJs` from the imported 'sql.js' module. The module is designed to load its own WASM file, and `sqliteService.js` correctly configures it to fetch from the CDN for browser environments.

This commit removes the redundant script tag from `index.html` to allow the `initSqlJs` function in `sqliteService.js` to manage the loading and initialization of SQL.js and its WASM file without interference. This should prevent the initialization process from hanging.