### PR TITLE
feat: Add load timer for data initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 <body>
     <div class="container">
         <h1>SQL.js CSV Reader</h1>
+        <div id="timer"></div>
         <div id="status">Initializing SQL.js...</div>
 
         <h2>Query Data</h2>

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,7 @@ import { initializeDatabase, generateTableNameFromUrl } from './db.js';
 import { executeQuery } from './query.js';
 import { fileSources } from './csvSources.js'; // Import the updated sources
 import { initializeCopyButton } from './ui/copyButton.js';
+import { startTimer, stopTimer, displayTime } from './ui/timer.js';
 
 const executeButton = document.getElementById('execute-button');
 
@@ -14,6 +15,7 @@ if (executeButton) {
 
 initializeCopyButton(); // Initialize the copy button functionality
 
+startTimer();
 // Initialize the database with the imported array of sources and then execute an initial query.
 initializeDatabase(fileSources) // Use the updated fileSources
     .then(() => {
@@ -37,6 +39,8 @@ initializeDatabase(fileSources) // Use the updated fileSources
         }
         console.log("Database initialized. Executing initial query...");
         executeQuery(); // Execute initial query to display data
+        stopTimer();
+        displayTime();
     })
     .catch(error => {
         console.error("Failed to initialize the application:", error);
@@ -44,4 +48,6 @@ initializeDatabase(fileSources) // Use the updated fileSources
         if (statusDiv) {
             statusDiv.innerHTML = `<p class="error">Application initialization failed: ${error.message}</p>`;
         }
+        stopTimer();
+        displayTime();
     });

--- a/js/ui/timer.js
+++ b/js/ui/timer.js
@@ -1,0 +1,41 @@
+let startTime;
+let endTime;
+
+/**
+ * Records the current time as the start time.
+ */
+function startTimer() {
+    startTime = new Date();
+}
+
+/**
+ * Records the current time as the end time and calculates the duration.
+ */
+function stopTimer() {
+    endTime = new Date();
+}
+
+/**
+ * Calculates the difference between startTime and endTime,
+ * and updates the 'timer' div in index.html with the duration.
+ * The time should be displayed in seconds with two decimal places (e.g., "Load time: 3.45s").
+ */
+function displayTime() {
+    if (startTime && endTime) {
+        const duration = (endTime - startTime) / 1000; // Duration in seconds
+        const timerDiv = document.getElementById('timer');
+        if (timerDiv) {
+            timerDiv.innerText = `Load time: ${duration.toFixed(2)}s`;
+        } else {
+            console.error("Timer display element not found.");
+        }
+    } else {
+        console.warn("Timer was not started or stopped correctly.");
+        const timerDiv = document.getElementById('timer');
+        if (timerDiv) {
+            timerDiv.innerText = "Timer error.";
+        }
+    }
+}
+
+export { startTimer, stopTimer, displayTime };


### PR DESCRIPTION
Added a timer to `index.html` to measure the duration of the data loading process.

Key changes:
- Modified `index.html` to include a `div#timer` element.
- Created `js/ui/timer.js` with `startTimer`, `stopTimer`, and `displayTime` functions.
- Integrated these timer functions into `js/main.js` to track the `initializeDatabase` operation.
- The timer starts before `initializeDatabase` is called and stops when it completes (either successfully or with an error).
- The load time is displayed in seconds with two decimal places in the `div#timer`.